### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/example/index.html
+++ b/example/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>cdg.js Demo Page</title>
-    <script data-main="main" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.22/require.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/screenfull.js/3.0.0/screenfull.min.js"></script>
+    <script data-main="main" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.22/require.min.js" integrity="sha384-m781XEmCcCEs8IC+uEhnyI5+iaLBxwxTZOFsLfqt+l2CJrIo3JXU5OiHJOC0s7H2" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/screenfull.js/3.0.0/screenfull.min.js" integrity="sha384-ezTfhTekwoet+hx8utk8yo5bsH9rCD0Lwdy6LxNrN/i5heQ6/9HjcY9eVQNyXSQQ" crossorigin="anonymous"></script>
     <style>
         body {
             font-size: 1em;


### PR DESCRIPTION
Potential fix for [https://github.com/willprescott/cdg.js/security/code-scanning/1](https://github.com/willprescott/cdg.js/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the current workflow. This change ensures that the workflow does not inadvertently gain unnecessary write permissions, improving security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
