### PR TITLE
Add npm run example dev server (fixes audio scrubbing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ It is now packaged as an ES module (previously an AMD module) to take advantage 
 See the files in the [example](./example) directory for a working demo implementation. You will need to provide your
 own CDG file and accompanying audio file for the demo to work (the example uses 2 files named `demo.cdg` and `demo.mp3`).
 
+Start the dev server by running `npm run example` in the project root directory, and then open `http://localhost:5173/` in your browser.
+
 ### Code examples
 
 Simply provide an empty container element in your HTML source with an ID:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
+    "example": "vite",
     "lint": "eslint src/",
     "test": "vitest"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,21 +3,28 @@ import { readFileSync } from "fs";
 
 const banner = readFileSync("./src/banner.txt", "utf8");
 
-export default defineConfig({
-  test: {
-    environment: "node",
-  },
-  build: {
-    lib: {
-      entry: "./src/cdg.js",
-      fileName: "cdg",
-      formats: ["es"],
+export default defineConfig(({ mode }) => {
+  const config = {
+    test: {
+      environment: "node",
     },
-    sourcemap: true,
-    rolldownOptions: {
-      output: {
-        banner: banner,
+    build: {
+      lib: {
+        entry: "./src/cdg.js",
+        fileName: "cdg",
+        formats: ["es"],
+      },
+      sourcemap: true,
+      rolldownOptions: {
+        output: {
+          banner: banner,
+        },
       },
     },
-  },
+  };
+  if (mode === "development") {
+    config.root = "example";
+    config.server = { fs: { allow: [".."] } };
+  }
+  return config;
 });


### PR DESCRIPTION
Related to #56.

## Summary
- Adds an `npm run example` script that runs Vite's dev server against `example/`
- Vite serves files with `Accept-Ranges: bytes` and responds to `Range` requests with `206 Partial Content`, which is what the browser needs to enable audio seeking
- `vite.config.js` gains a conditional dev-server block (\`root: \"example\"\`, \`server.fs.allow: [\"..\"]\`) keyed on \`mode === \"development\"\` so it only kicks in for the dev server — \`vite build\` and \`vitest\` continue to use the project root

## Why
Audio scrubbing in the demo was silently broken when serving via \`python -m http.server\`, which doesn't support \`Range\` requests. The browser sees no \`Accept-Ranges\` header, reports \`audio.seekable\` as \`[0, 0]\`, and quietly aborts any user-initiated seek (no \`seeked\` event ever fires). Vite's dev server doesn't have this limitation.

## Test plan
- [x] \`npm test -- --run\` — all 15 tests pass
- [x] \`npm run lint\` — no warnings
- [x] \`npm run build\` — clean lib build
- [x] \`npm run example\` — server starts; \`curl -I -H 'Range: bytes=0-99' http://localhost:5173/demo.mp3\` returns \`206 Partial Content\` with \`Accept-Ranges: bytes\`
- [x] Manual: load \`http://localhost:5173/\` in a browser, play the demo, and confirm the audio scrubber now seeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)