### PR TITLE
Add test for init() public entry point in cdg.js

### DIFF
--- a/tests/cdgPlayer.test.js
+++ b/tests/cdgPlayer.test.js
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { CDGPlayer } from "../src/CDGPlayer.js";
 import { CDGDecoder } from "../src/CDGDecoder.js";
+import { init } from "../src/cdg.js";
 
 vi.mock("../src/CDGDecoder.js", () => ({
   CDGDecoder: vi.fn().mockImplementation(function () {
@@ -48,6 +49,18 @@ describe("CDGPlayer", () => {
       expect(document.getElementById("player-border").className).toBe("cdg-border");
       expect(document.getElementById("player-canvas").className).toBe("cdg-canvas");
       expect(document.getElementById("player-audio").className).toBe("cdg-audio");
+    });
+  });
+
+  // ── init() public factory ────────────────────────────────────────────────────
+
+  describe("init()", () => {
+    it("creates and returns a CDGPlayer via the cdg.js public entry point", () => {
+      const el = document.createElement("div");
+      el.id = "init-player";
+      document.body.appendChild(el);
+      const player = init("init-player");
+      expect(player).toBeInstanceOf(CDGPlayer);
     });
   });
 


### PR DESCRIPTION
## Summary

The `init()` wrapper function in `src/cdg.js` was the only remaining uncovered line across the codebase. SonarQube flagged it as 0% line coverage for the file.

## Change

Adds a single test to `cdgPlayer.test.js` that imports and calls `init()` via the public `cdg.js` module, verifying it returns a `CDGPlayer` instance.

## Coverage after

| File | Stmts | Funcs | Lines | Branches |
|---|---|---|---|---|
| `CDGDecoder.js` | 100% | 100% | 100% | 95.6% |
| `cdg.js` | 100% | 100% | 100% | 100% |
| **All files** | **100%** | **100%** | **100%** | **97.4%** |

The 3 remaining partial branches in `CDGDecoder.js` are structurally unreachable (one dead false-branch, two require an invalid scroll direction value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)